### PR TITLE
Implement presence scores and allow evaluation per group

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,10 @@ def query_ref_adata(adata_pbmc3k):
     )
     query = query[:, query_genes].copy()
 
+    # Introduce two deterministic batch categories in the query AnnData object
+    query.obs["batch"] = np.repeat(["A", "B"], repeats=n_query_cells // 2).tolist()
+    query.obs["batch"] = query.obs["batch"].astype("category")
+
     return query, ref
 
 
@@ -124,7 +128,7 @@ def expected_label_transfer_metrics():
 def expected_expression_transfer_metrics():
     return {
         "method": "pearson",
-        "average_correlation": 0.376,
+        "average": 0.376,
         "n_genes": 300,
         "n_valid_genes": 300,
     }

--- a/tests/test_cellmapper.py
+++ b/tests/test_cellmapper.py
@@ -40,15 +40,6 @@ class TestCellMapper:
         assert cmap.query_imputed is not None
         assert cmap.query_imputed.X.shape[0] == cmap.query.n_obs
 
-    @pytest.mark.parametrize("eval_layer", ["X", "counts"])
-    @pytest.mark.parametrize("method", ["pearson", "spearman", "js", "rmse"])
-    def test_evaluate_expression_transfer_layers_and_methods(self, cmap, eval_layer, method):
-        cmap.transfer_expression(layer_key="X")
-        cmap.evaluate_expression_transfer(layer_key=eval_layer, method=method)
-        metrics = cmap.expression_transfer_metrics
-        assert metrics["method"] == method
-        assert metrics["n_valid_genes"] > 0
-
     @pytest.mark.parametrize(
         "joint_pca_key,n_pca_components,pca_kwargs",
         [

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,17 @@
+import pytest
+
+
+class TestEvaluate:
+    @pytest.mark.parametrize("eval_layer", ["X", "counts"])
+    @pytest.mark.parametrize("method", ["pearson", "spearman", "js", "rmse"])
+    @pytest.mark.parametrize("groupby", ["batch", "modality"])
+    def test_evaluate_expression_transfer_layers_and_methods(self, cmap, eval_layer, method, groupby):
+        cmap.transfer_expression(layer_key="X")
+        cmap.evaluate_expression_transfer(layer_key=eval_layer, method=method, groupby=groupby)
+        metrics = cmap.expression_transfer_metrics
+        assert metrics["method"] == method
+        assert metrics["n_valid_genes"] > 0
+        assert cmap.query_imputed is not None
+        assert cmap.query.var[f"metric_{method}"] is not None
+        if groupby == "batch":
+            assert cmap.query.varm[f"metric_{method}"] is not None


### PR DESCRIPTION
Includes a `groupby` parameter for both presence scores and expression transfer evaluation. 

closes #13 