### PR TITLE
Work with pre-computed objects for imputed values and k-NN graphs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ optional-dependencies.doc = [
 optional-dependencies.test = [
   "coverage",
   "pytest",
+  "squidpy",
 ]
 optional-dependencies.tutorials = [
   "harmony-pytorch",

--- a/src/cellmapper/cellmapper.py
+++ b/src/cellmapper/cellmapper.py
@@ -559,13 +559,13 @@ class CellMapper(CellMapperEvaluationMixin):
         if not self._is_self_mapping:
             raise ValueError("Pre-computed distances can only be used in self-mapping mode")
 
-        if distances_key not in self.reference.obsp:
-            raise KeyError(f"Distance matrix '{distances_key}' not found in reference.obsp")
+        if distances_key not in self.query.obsp:
+            raise KeyError(f"Distance matrix '{distances_key}' not found in query.obsp")
 
-        self.knn = Neighbors.from_distances(self.reference.obsp[distances_key])
+        self.knn = Neighbors.from_distances(self.query.obsp[distances_key])
 
         logger.info(
-            "Loaded pre-computed distance matrix from reference.obsp['%s'] with %d cells",
+            "Loaded pre-computed distance matrix from query.obsp['%s'] with %d cells",
             distances_key,
-            self.reference.n_obs,
+            self.query.n_obs,
         )

--- a/src/cellmapper/cellmapper.py
+++ b/src/cellmapper/cellmapper.py
@@ -61,12 +61,13 @@ class CellMapper(CellMapperEvaluationMixin):
 
     def __repr__(self):
         """Return a concise string representation of the CellMapper object."""
-        reference_summary = f"AnnData(n_obs={self.reference.n_obs:,}, n_vars={self.reference.n_vars:,})"
         query_summary = f"AnnData(n_obs={self.query.n_obs:,}, n_vars={self.query.n_vars:,})"
-        return (
-            f"CellMapper(reference={reference_summary}, query={query_summary}, "
-            f"Mapping mode: {'self-mapping' if self._is_self_mapping else 'cross-mapping'}."
-        )
+
+        if self._is_self_mapping:
+            return f"CellMapper(self-mapping, data={query_summary}, "
+        else:
+            reference_summary = f"AnnData(n_obs={self.reference.n_obs:,}, n_vars={self.reference.n_vars:,})"
+            return f"CellMapper(query={query_summary}, reference={reference_summary}"
 
     @property
     def mapping_matrix(self):

--- a/src/cellmapper/cellmapper.py
+++ b/src/cellmapper/cellmapper.py
@@ -21,7 +21,7 @@ from .knn import Neighbors
 class CellMapper(CellMapperEvaluationMixin):
     """Mapping of labels, embeddings, and expression values between reference and query datasets."""
 
-    def __init__(self, ref: AnnData, query: AnnData | None) -> None:
+    def __init__(self, ref: AnnData, query: AnnData | None = None) -> None:
         """
         Initialize the CellMapper class.
 
@@ -66,9 +66,7 @@ class CellMapper(CellMapperEvaluationMixin):
         query_summary = f"AnnData(n_obs={self.query.n_obs:,}, n_vars={self.query.n_vars:,})"
         return (
             f"CellMapper(ref={ref_summary}, query={query_summary}, "
-            f"n_neighbors={self.n_neighbors}, "
-            f"prediction_postfix={self.prediction_postfix}, "
-            f"confidence_postfix={self.confidence_postfix})"
+            f"Mapping mode: {'self-mapping' if self._is_self_mapping else 'cross-mapping'}, "
         )
 
     @property

--- a/src/cellmapper/cellmapper.py
+++ b/src/cellmapper/cellmapper.py
@@ -199,6 +199,7 @@ class CellMapper(CellMapperEvaluationMixin):
             Data representation based on which to find nearest neighbors. If None, a joint PCA will be computed.
         method
             Method to use for computing neighbors. "sklearn" and "pynndescent" run on CPU, "rapids" and "faiss" run on GPU. Note that all but "pynndescent" perform exact neighbor search. With GPU acceleration, "faiss" is usually fastest and more memory efficient than "rapids".
+            All methods return exactly `n_neighbors` neighbors, including the reference cell itself (in self-mapping mode). For faiss and sklearn, distances to self are very small positive numbers, for rapids and sklearn, they are exactly 0.
         metric
             Distance metric to use for nearest neighbors.
         only_yx

--- a/src/cellmapper/check.py
+++ b/src/cellmapper/check.py
@@ -57,14 +57,17 @@ class Checker:
 
 
 INSTALL_HINTS = types.SimpleNamespace(
-    rapids="To speed up k-NN search on GPU, you may install rapids following the guide from "
-    "https://docs.rapids.ai/install/. Note that you will only need cuML.",
+    cuml="To speed up k-NN search on GPU, you may install cuML following the guide from "
+    "https://docs.rapids.ai/install/.",
+    cupy="To speed up k-NN search on GPU, you may install cuPy following the guide from "
+    "https://docs.rapids.ai/install/.",
     faiss="To speed up k-NN search on GPU, you may install faiss following the guide from "
     "https://github.com/facebookresearch/faiss/blob/main/INSTALL.md",
 )
 
 CHECKERS = {
-    "rapids": Checker("rapids", vmin=None, install_hint=INSTALL_HINTS.rapids),
+    "cuml": Checker("cuml", vmin=None, install_hint=INSTALL_HINTS.cuml),
+    "cupy": Checker("cupy", vmin=None, install_hint=INSTALL_HINTS.cupy),
     "faiss": Checker("faiss", package_name="faiss", vmin="1.7.0", install_hint=INSTALL_HINTS.faiss),
 }
 

--- a/src/cellmapper/evaluate.py
+++ b/src/cellmapper/evaluate.py
@@ -35,8 +35,6 @@ def _jensen_shannon_divergence(p: np.ndarray, q: np.ndarray) -> float:
     q = np.clip(q, 0, None)
     if p.sum() == 0 or q.sum() == 0:
         return np.nan
-    p = p / p.sum()
-    q = q / q.sum()
     return jensenshannon(p, q, base=10)
 
 
@@ -226,7 +224,11 @@ class CellMapperEvaluationMixin:
 
         # Helper to compute metrics for a given mask of cells
         def compute_metrics(mask):
-            return np.array([metric_func(original_x[mask, i], imputed_x[mask, i]) for i in range(imputed_x.shape[1])])
+            # Explicitly return as float32 to match DataFrame's dtype
+            return np.array(
+                [metric_func(original_x[mask, i], imputed_x[mask, i]) for i in range(imputed_x.shape[1])],
+                dtype=np.float32,
+            )
 
         # Compute metrics for all cells
         overall_mask = np.ones(original_x.shape[0], dtype=bool)
@@ -273,7 +275,9 @@ class CellMapperEvaluationMixin:
         imputed_x, original_x, shared_genes
         """
         if self.query_imputed is None:
-            raise ValueError("Imputed query data not found. Run transfer_expression() first.")
+            raise ValueError(
+                "Imputed query data not found. Either run transfer_expression() first or set query_imputed manually."
+            )
         shared_genes = list(self.query_imputed.var_names.intersection(self.query.var_names))
         if len(shared_genes) == 0:
             raise ValueError("No shared genes between query_imputed and query.")

--- a/src/cellmapper/evaluate.py
+++ b/src/cellmapper/evaluate.py
@@ -391,11 +391,11 @@ class CellMapperEvaluationMixin:
             raise ValueError("Neighbors must be computed before estimating presence scores.")
 
         conn = self.knn.yx.knn_graph_connectivities()
-        ref_names = self.reference.obs_names
+        reference_names = self.reference.obs_names
 
         # Always compute and post-process the overall score (all query cells)
         scores_all = np.array(conn.sum(axis=0)).flatten()
-        df_all = pd.DataFrame({"all": scores_all}, index=ref_names)
+        df_all = pd.DataFrame({"all": scores_all}, index=reference_names)
         df_all_processed = process_presence_scores(df_all, log=log, percentile=percentile)
         self.reference.obs[key_added] = df_all_processed["all"]
         logger.info("Presence score across all query cells computed and stored in `reference.obs['%s']`", key_added)
@@ -404,12 +404,12 @@ class CellMapperEvaluationMixin:
         if groupby is not None:
             group_labels = self.query.obs[groupby]
             groups = group_labels.unique()
-            score_matrix = np.zeros((len(ref_names), len(groups)), dtype=np.float32)
+            score_matrix = np.zeros((len(reference_names), len(groups)), dtype=np.float32)
             for i, group in enumerate(groups):
                 mask = group_labels == group
                 group_conn = conn[mask.values, :]
                 score_matrix[:, i] = np.array(group_conn.sum(axis=0)).flatten()
-            df_groups = pd.DataFrame(score_matrix, index=ref_names, columns=groups)
+            df_groups = pd.DataFrame(score_matrix, index=reference_names, columns=groups)
             df_groups_processed = process_presence_scores(df_groups, log=log, percentile=percentile)
             self.reference.obsm[key_added] = df_groups_processed
 

--- a/src/cellmapper/evaluate.py
+++ b/src/cellmapper/evaluate.py
@@ -380,8 +380,8 @@ class CellMapperEvaluationMixin:
         groupby
             Column in self.query.obs to group query cells by (e.g., cell type, batch). If None, computes a single score for all query cells.
         key_added
-            Key to store the presence score: always writes the score across all query cells to self.ref.obs[key_added].
-            If groupby is not None, also writes per-group scores as a DataFrame to self.ref.obsm[key_added].
+            Key to store the presence score: always writes the score across all query cells to self.reference.obs[key_added].
+            If groupby is not None, also writes per-group scores as a DataFrame to self.reference.obsm[key_added].
         log
             Whether to apply log1p transformation to the scores.
         percentile
@@ -391,14 +391,14 @@ class CellMapperEvaluationMixin:
             raise ValueError("Neighbors must be computed before estimating presence scores.")
 
         conn = self.knn.yx.knn_graph_connectivities()
-        ref_names = self.ref.obs_names
+        ref_names = self.reference.obs_names
 
         # Always compute and post-process the overall score (all query cells)
         scores_all = np.array(conn.sum(axis=0)).flatten()
         df_all = pd.DataFrame({"all": scores_all}, index=ref_names)
         df_all_processed = process_presence_scores(df_all, log=log, percentile=percentile)
-        self.ref.obs[key_added] = df_all_processed["all"]
-        logger.info("Presence score across all query cells computed and stored in `ref.obs['%s']`", key_added)
+        self.reference.obs[key_added] = df_all_processed["all"]
+        logger.info("Presence score across all query cells computed and stored in `reference.obs['%s']`", key_added)
 
         # If groupby, also compute and post-process per-group scores
         if groupby is not None:
@@ -411,10 +411,10 @@ class CellMapperEvaluationMixin:
                 score_matrix[:, i] = np.array(group_conn.sum(axis=0)).flatten()
             df_groups = pd.DataFrame(score_matrix, index=ref_names, columns=groups)
             df_groups_processed = process_presence_scores(df_groups, log=log, percentile=percentile)
-            self.ref.obsm[key_added] = df_groups_processed
+            self.reference.obsm[key_added] = df_groups_processed
 
             logger.info(
-                "Presence scores per group defined in `query.obs['%s']` computed and stored in `ref.obsm['%s']`",
+                "Presence scores per group defined in `query.obs['%s']` computed and stored in `reference.obsm['%s']`",
                 groupby,
                 key_added,
             )

--- a/src/cellmapper/knn.py
+++ b/src/cellmapper/knn.py
@@ -351,8 +351,10 @@ class Neighbors:
             logger.info("Using %s to compute %d neighbors.", method, n_neighbors)
 
             if method == "rapids":
-                check_deps("rapids")
+                check_deps("cuml")
                 import cuml as cm
+
+                check_deps("cupy")
                 import cupy as cp
 
                 xrep_gpu = cp.asarray(self.xrep)

--- a/src/cellmapper/knn.py
+++ b/src/cellmapper/knn.py
@@ -292,7 +292,7 @@ class Neighbors:
         self._is_self_mapping = yrep is None
 
     @classmethod
-    def from_distances(cls, distances_matrix: "csr_matrix") -> "Neighbors":
+    def from_distances(cls, distances_matrix: "csr_matrix", include_self: bool | None = None) -> "Neighbors":
         """
         Create a Neighbors object from a pre-computed distances matrix.
 
@@ -300,6 +300,10 @@ class Neighbors:
         ----------
         distances_matrix
             Sparse distance matrix, typically from adata.obsp['distances']
+        include_self
+            If True, include self as a neighbor (cells are their own neighbors).
+            If False, exclude self connections, even if present in the distance matrix.
+            If None (default), preserve the original behavior of the distance matrix.
 
         Returns
         -------
@@ -307,7 +311,7 @@ class Neighbors:
             A new Neighbors object with pre-computed neighbor information
         """
         # Extract indices and distances from the sparse matrix
-        indices, distances = extract_neighbors_from_distances(distances_matrix)
+        indices, distances = extract_neighbors_from_distances(distances_matrix, include_self=include_self)
 
         # Create a minimal Neighbors object for self-mapping
         n_cells = distances_matrix.shape[0]
@@ -322,6 +326,9 @@ class Neighbors:
         neighbors.yy = neighbors_result
         neighbors.xy = neighbors_result
         neighbors.yx = neighbors_result
+
+        # Mark as self-mapping
+        neighbors._is_self_mapping = True
 
         logger.info("Created Neighbors object from distances matrix with %d cells", n_cells)
 

--- a/src/cellmapper/knn.py
+++ b/src/cellmapper/knn.py
@@ -223,7 +223,7 @@ class NeighborsResults:
 
         return connectivities
 
-    def boolean_adjacency(self, dtype=np.float64) -> csr_matrix:
+    def boolean_adjacency(self, dtype=np.float64, set_diag: bool | None = None) -> csr_matrix:
         """
         Construct a boolean adjacency matrix from neighbor indices.
 
@@ -231,6 +231,10 @@ class NeighborsResults:
         ----------
         dtype
             Data type for the matrix values.
+        set_diag
+            If True, set the diagonal to 1. If False, set the diagonal to 0.
+            If None, do not modify the diagonal - whether it's 0 or 1 depends on the neighbor algorithm.
+            This parameter can only be used with square matrices.
 
         Returns
         -------
@@ -244,7 +248,20 @@ class NeighborsResults:
         ones = np.ones_like(self.indices, dtype=dtype)
 
         # Create sparse matrix with ones as values for valid entries
-        return self._create_sparse_matrix(ones, valid_mask, dtype=dtype)
+        adj_matrix = self._create_sparse_matrix(ones, valid_mask, dtype=dtype)
+
+        # Handle the diagonal based on set_diag parameter
+        if set_diag is not None:
+            # Check that we have a square matrix
+            if self.shape[0] != self.shape[1]:
+                raise ValueError(
+                    "The set_diag parameter can only be used with square matrices "
+                    f"(got shape {self.shape[0]} x {self.shape[1]})."
+                )
+            # Use setdiag to efficiently set diagonal elements
+            adj_matrix.setdiag(1.0 if set_diag else 0.0)
+
+        return adj_matrix
 
 
 class Neighbors:

--- a/src/cellmapper/knn.py
+++ b/src/cellmapper/knn.py
@@ -17,7 +17,9 @@ from .utils import extract_neighbors_from_distances
 class NeighborsResults:
     """Nearest neighbors results data store.
 
-    Adapted from the scib-metrics package: https://github.com/YosefLab/scib-metrics
+    Adapted from the scib-metrics package: https://github.com/YosefLab/scib-metrics. Extended to non-square matrices and potentially
+    varying number of neighbors per cell. This class is used to store the results of nearest neighbor searches, including
+    distances and indices of the nearest neighbors. It also provides methods to compute adjacency matrices and connectivities based on the nearest neighbors.
 
     Attributes
     ----------

--- a/src/cellmapper/utils.py
+++ b/src/cellmapper/utils.py
@@ -1,0 +1,121 @@
+"""Utility functions for the CellMapper package."""
+
+import anndata as ad
+import numpy as np
+import pandas as pd
+from anndata import AnnData
+from scipy.sparse import csr_matrix
+
+from cellmapper.logging import logger
+
+
+def create_imputed_anndata(
+    expression_data: np.ndarray | csr_matrix | pd.DataFrame | AnnData,
+    query_adata: AnnData,
+    ref_adata: AnnData,
+) -> AnnData:
+    """
+    Create an AnnData object for imputed expression data with validation and conversion.
+
+    This function handles validation, conversion, and construction of an AnnData object
+    from imputed expression data, taking observation metadata from the query and
+    feature metadata from the reference.
+
+    Parameters
+    ----------
+    expression_data
+        The imputed expression data in one of these formats:
+        - A numpy array with shape (n_query_cells, n_ref_genes)
+        - A sparse matrix with shape (n_query_cells, n_ref_genes)
+        - A pandas DataFrame with shape (n_query_cells, n_ref_genes)
+        - An existing AnnData object with n_obs matching query_adata
+    query_adata
+        Query AnnData object providing observation metadata (obs, obsm).
+    ref_adata
+        Reference AnnData object providing feature metadata (var, varm).
+
+    Returns
+    -------
+    AnnData
+        An AnnData object containing the imputed expression with aligned metadata.
+
+    Notes
+    -----
+    The returned AnnData object will have:
+    - X: The imputed expression data
+    - obs: Reference to query_adata.obs (not copied)
+    - var: Reference to ref_adata.var (not copied)
+    - obsm: Reference to query_adata.obsm (not copied)
+    - varm: Reference to ref_adata.varm if available (not copied)
+    - uns: Deep copy from query_adata.uns since it can contain complex objects
+    """
+    # Check for unsupported types first
+    if not isinstance(expression_data, np.ndarray | csr_matrix | pd.DataFrame | AnnData):
+        raise TypeError(
+            f"Unsupported type for expression_data: {type(expression_data)}. "
+            "Must be AnnData, numpy array, sparse matrix, or pandas DataFrame."
+        )
+
+    # Case 1: Handle existing AnnData object
+    if isinstance(expression_data, AnnData):
+        # Validate that the imputed data has the same number of observations as the query
+        if expression_data.n_obs != query_adata.n_obs:
+            raise ValueError(
+                f"Imputed AnnData has {expression_data.n_obs} observations, but query has {query_adata.n_obs} observations. "
+                "They must have the same number of observations."
+            )
+
+        # Check if the observations are aligned (same order)
+        if not expression_data.obs_names.equals(query_adata.obs_names):
+            logger.warning(
+                "Observation names in imputed AnnData don't match query observation names. "
+                "Make sure the cells are aligned correctly."
+            )
+
+        logger.info("Using existing AnnData object with %d genes as imputed data.", expression_data.n_vars)
+        return expression_data
+
+    # Case 2: Handle DataFrame
+    if isinstance(expression_data, pd.DataFrame):
+        # Check if DataFrame dimensions match expected dimensions
+        if len(expression_data.index) != query_adata.n_obs:
+            raise ValueError(
+                f"DataFrame has {len(expression_data.index)} rows, but query has {query_adata.n_obs} observations. "
+                "They must match."
+            )
+
+        if len(expression_data.columns) != ref_adata.n_vars:
+            raise ValueError(
+                f"DataFrame has {len(expression_data.columns)} columns, but reference has {ref_adata.n_vars} features. "
+                "They must match."
+            )
+
+        # Convert to numpy array for consistency
+        expression_data = expression_data.values
+
+    # Case 3: Handle numpy arrays and sparse matrices
+    # Validate shape
+    expected_shape = (query_adata.n_obs, ref_adata.n_vars)
+    if expression_data.shape != expected_shape:
+        raise ValueError(
+            f"Expression data shape mismatch: expected {expected_shape}, but got {expression_data.shape}. "
+            f"Should be (n_query_cells, n_ref_genes)."
+        )
+
+    # Create a new AnnData object without copying data where possible
+    imputed_adata = ad.AnnData(
+        X=expression_data,
+        obs=query_adata.obs,  # No copy - direct reference
+        var=ref_adata.var,  # No copy - direct reference
+        uns=query_adata.uns.copy(),  # Deep copy since uns can contain complex objects
+        obsm=query_adata.obsm,  # No copy - direct reference
+        varm=ref_adata.varm if hasattr(ref_adata, "varm") and ref_adata.varm is not None else None,  # No copy
+    )
+
+    logger.info(
+        "Imputed expression matrix with shape %s converted to AnnData object.\n"
+        "Observation metadata from query and feature metadata from reference were linked (not copied).",
+        expression_data.shape,
+    )
+
+    return imputed_adata

--- a/src/cellmapper/utils.py
+++ b/src/cellmapper/utils.py
@@ -141,13 +141,24 @@ def extract_neighbors_from_distances(distances_matrix: "csr_matrix") -> tuple[np
 
     n_cells = distances_matrix.shape[0]
 
-    # Get the maximum number of neighbors per cell
+    # Get the number of neighbors per cell
     n_neighbors_per_cell = np.diff(distances_matrix.indptr)
     max_n_neighbors = n_neighbors_per_cell.max()
+    min_n_neighbors = n_neighbors_per_cell.min()
+
+    # Check if all cells have the same number of neighbors
+    if max_n_neighbors != min_n_neighbors:
+        logger.warning(
+            "Variable neighborhood sizes detected: min=%d, max=%d neighbors per cell. "
+            "Some cells may have fewer neighbors than others, which could affect results.",
+            min_n_neighbors,
+            max_n_neighbors,
+        )
 
     # Pre-allocate arrays for indices and distances
-    indices = np.zeros((n_cells, max_n_neighbors), dtype=np.int64)
-    distances = np.ones((n_cells, max_n_neighbors), dtype=np.float64) * np.inf
+    # Use -1 as a sentinel value for missing neighbors (better than 0 which is a valid index)
+    indices = np.full((n_cells, max_n_neighbors), -1, dtype=np.int64)
+    distances = np.full((n_cells, max_n_neighbors), np.inf, dtype=np.float64)
 
     # Extract indices and distances for each cell
     for i in range(n_cells):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,52 @@ def expected_expression_transfer_metrics():
         "n_shared_genes": 300,
         "n_test_genes": 300,
     }
+
+
+@pytest.fixture
+def evaluation_methods():
+    """Fixture providing a list of evaluation methods for expression transfer."""
+    return ["pearson", "spearman", "js", "rmse"]
+
+
+@pytest.fixture
+def random_imputed_data(query_ref_adata):
+    """Fixture providing random expression data with the right shape for query_imputed testing."""
+    query, ref = query_ref_adata
+    return np.random.rand(query.n_obs, ref.n_vars)
+
+
+@pytest.fixture
+def sparse_imputed_data(query_ref_adata):
+    """Fixture providing a sparse expression matrix for query_imputed testing."""
+    from scipy.sparse import csr_matrix
+
+    query, ref = query_ref_adata
+    return csr_matrix(np.random.rand(query.n_obs, ref.n_vars))
+
+
+@pytest.fixture
+def dataframe_imputed_data(query_ref_adata):
+    """Fixture providing a pandas DataFrame with expression data for query_imputed testing."""
+    import pandas as pd
+
+    query, ref = query_ref_adata
+    return pd.DataFrame(np.random.rand(query.n_obs, ref.n_vars), index=query.obs_names, columns=ref.var_names)
+
+
+@pytest.fixture
+def custom_anndata_imputed(query_ref_adata):
+    """Fixture providing a custom AnnData object for query_imputed testing."""
+    import anndata as ad
+
+    query, ref = query_ref_adata
+    return ad.AnnData(X=np.random.rand(query.n_obs, ref.n_vars), obs=query.obs.copy(), var=ref.var.copy())
+
+
+@pytest.fixture
+def invalid_shape_data(query_ref_adata):
+    """Fixture providing expression matrices with invalid shapes."""
+    query, ref = query_ref_adata
+    too_few_cells = np.random.rand(query.n_obs - 5, ref.n_vars)
+    too_few_genes = np.random.rand(query.n_obs, ref.n_vars - 10)
+    return {"too_few_cells": too_few_cells, "too_few_genes": too_few_genes}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,15 +66,15 @@ def adata_pbmc3k(precomputed_leiden):
 
 
 @pytest.fixture
-def query_ref_adata(adata_pbmc3k):
+def query_reference_adata(adata_pbmc3k):
     # Define the number of query cells and genes
     n_query_cells = 500
     n_query_genes = 300
-    n_ref_cells = adata_pbmc3k.n_obs - n_query_cells
+    n_reference_cells = adata_pbmc3k.n_obs - n_query_cells
 
     # Create modality annotations in the AnnData object
     adata_pbmc3k.obs["modality"] = (
-        np.repeat("query", repeats=n_query_cells).tolist() + np.repeat("reference", repeats=n_ref_cells).tolist()
+        np.repeat("query", repeats=n_query_cells).tolist() + np.repeat("reference", repeats=n_reference_cells).tolist()
     )
     adata_pbmc3k.obs["modality"] = adata_pbmc3k.obs["modality"].astype("category")
 
@@ -96,8 +96,8 @@ def query_ref_adata(adata_pbmc3k):
 
 
 @pytest.fixture
-def cmap(query_ref_adata):
-    query, reference = query_ref_adata
+def cmap(query_reference_adata):
+    query, reference = query_reference_adata
 
     # Create a CellMapper object
     cmap = CellMapper(
@@ -141,45 +141,45 @@ def evaluation_methods():
 
 
 @pytest.fixture
-def random_imputed_data(query_ref_adata):
+def random_imputed_data(query_reference_adata):
     """Fixture providing random expression data with the right shape for query_imputed testing."""
-    query, reference = query_ref_adata
+    query, reference = query_reference_adata
     return np.random.rand(query.n_obs, reference.n_vars)
 
 
 @pytest.fixture
-def sparse_imputed_data(query_ref_adata):
+def sparse_imputed_data(query_reference_adata):
     """Fixture providing a sparse expression matrix for query_imputed testing."""
     from scipy.sparse import csr_matrix
 
-    query, reference = query_ref_adata
+    query, reference = query_reference_adata
     return csr_matrix(np.random.rand(query.n_obs, reference.n_vars))
 
 
 @pytest.fixture
-def dataframe_imputed_data(query_ref_adata):
+def dataframe_imputed_data(query_reference_adata):
     """Fixture providing a pandas DataFrame with expression data for query_imputed testing."""
     import pandas as pd
 
-    query, reference = query_ref_adata
+    query, reference = query_reference_adata
     return pd.DataFrame(
         np.random.rand(query.n_obs, reference.n_vars), index=query.obs_names, columns=reference.var_names
     )
 
 
 @pytest.fixture
-def custom_anndata_imputed(query_ref_adata):
+def custom_anndata_imputed(query_reference_adata):
     """Fixture providing a custom AnnData object for query_imputed testing."""
     import anndata as ad
 
-    query, reference = query_ref_adata
+    query, reference = query_reference_adata
     return ad.AnnData(X=np.random.rand(query.n_obs, reference.n_vars), obs=query.obs.copy(), var=reference.var.copy())
 
 
 @pytest.fixture
-def invalid_shape_data(query_ref_adata):
+def invalid_shape_data(query_reference_adata):
     """Fixture providing expression matrices with invalid shapes."""
-    query, reference = query_ref_adata
+    query, reference = query_reference_adata
     too_few_cells = np.random.rand(query.n_obs - 5, reference.n_vars)
     too_few_genes = np.random.rand(query.n_obs, reference.n_vars - 10)
     return {"too_few_cells": too_few_cells, "too_few_genes": too_few_genes}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,13 +74,13 @@ def query_ref_adata(adata_pbmc3k):
 
     # Create modality annotations in the AnnData object
     adata_pbmc3k.obs["modality"] = (
-        np.repeat("query", repeats=n_query_cells).tolist() + np.repeat("ref", repeats=n_ref_cells).tolist()
+        np.repeat("query", repeats=n_query_cells).tolist() + np.repeat("reference", repeats=n_ref_cells).tolist()
     )
     adata_pbmc3k.obs["modality"] = adata_pbmc3k.obs["modality"].astype("category")
 
     # use these annotations to create query and reference AnnData objects
     query = adata_pbmc3k[adata_pbmc3k.obs["modality"] == "query"].copy()
-    ref = adata_pbmc3k[adata_pbmc3k.obs["modality"] == "ref"].copy()
+    reference = adata_pbmc3k[adata_pbmc3k.obs["modality"] == "reference"].copy()
 
     # Subset genes in the query AnnData object
     query_genes = (
@@ -92,17 +92,17 @@ def query_ref_adata(adata_pbmc3k):
     query.obs["batch"] = np.repeat(["A", "B"], repeats=n_query_cells // 2).tolist()
     query.obs["batch"] = query.obs["batch"].astype("category")
 
-    return query, ref
+    return query, reference
 
 
 @pytest.fixture
 def cmap(query_ref_adata):
-    query, ref = query_ref_adata
+    query, reference = query_ref_adata
 
     # Create a CellMapper object
     cmap = CellMapper(
         query=query,
-        ref=ref,
+        reference=reference,
     )
 
     # Compute neighbors and mapping matrix
@@ -143,8 +143,8 @@ def evaluation_methods():
 @pytest.fixture
 def random_imputed_data(query_ref_adata):
     """Fixture providing random expression data with the right shape for query_imputed testing."""
-    query, ref = query_ref_adata
-    return np.random.rand(query.n_obs, ref.n_vars)
+    query, reference = query_ref_adata
+    return np.random.rand(query.n_obs, reference.n_vars)
 
 
 @pytest.fixture
@@ -152,8 +152,8 @@ def sparse_imputed_data(query_ref_adata):
     """Fixture providing a sparse expression matrix for query_imputed testing."""
     from scipy.sparse import csr_matrix
 
-    query, ref = query_ref_adata
-    return csr_matrix(np.random.rand(query.n_obs, ref.n_vars))
+    query, reference = query_ref_adata
+    return csr_matrix(np.random.rand(query.n_obs, reference.n_vars))
 
 
 @pytest.fixture
@@ -161,8 +161,10 @@ def dataframe_imputed_data(query_ref_adata):
     """Fixture providing a pandas DataFrame with expression data for query_imputed testing."""
     import pandas as pd
 
-    query, ref = query_ref_adata
-    return pd.DataFrame(np.random.rand(query.n_obs, ref.n_vars), index=query.obs_names, columns=ref.var_names)
+    query, reference = query_ref_adata
+    return pd.DataFrame(
+        np.random.rand(query.n_obs, reference.n_vars), index=query.obs_names, columns=reference.var_names
+    )
 
 
 @pytest.fixture
@@ -170,14 +172,14 @@ def custom_anndata_imputed(query_ref_adata):
     """Fixture providing a custom AnnData object for query_imputed testing."""
     import anndata as ad
 
-    query, ref = query_ref_adata
-    return ad.AnnData(X=np.random.rand(query.n_obs, ref.n_vars), obs=query.obs.copy(), var=ref.var.copy())
+    query, reference = query_ref_adata
+    return ad.AnnData(X=np.random.rand(query.n_obs, reference.n_vars), obs=query.obs.copy(), var=reference.var.copy())
 
 
 @pytest.fixture
 def invalid_shape_data(query_ref_adata):
     """Fixture providing expression matrices with invalid shapes."""
-    query, ref = query_ref_adata
-    too_few_cells = np.random.rand(query.n_obs - 5, ref.n_vars)
-    too_few_genes = np.random.rand(query.n_obs, ref.n_vars - 10)
+    query, reference = query_ref_adata
+    too_few_cells = np.random.rand(query.n_obs - 5, reference.n_vars)
+    too_few_genes = np.random.rand(query.n_obs, reference.n_vars - 10)
     return {"too_few_cells": too_few_cells, "too_few_genes": too_few_genes}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,76 @@ def adata_pbmc3k(precomputed_leiden):
 
 
 @pytest.fixture
+def adata_spatial(adata_pbmc3k):
+    """Fixture to load spatial data with realistic coordinates for testing distance calculations.
+
+    This can be used to test the loading of pre-computed distance matrices. It contains toy spatial
+    coordinates and batches, so that neighbors can be computed with either scanpy or squidpy.
+
+    Spatial patterns:
+    - Batch A: Concentric rings structure (inner and outer ring)
+    - Batch B: Grid-like pattern
+
+    The patterns have some overlap in the center of the coordinate system, creating a
+    biologically plausible scenario where different cell types might be present in the same area.
+    """
+    # Get number of observations
+    n_obs = adata_pbmc3k.n_obs
+    n_half = n_obs // 2
+
+    # Introduce batch categories first
+    adata_pbmc3k.obs["batch"] = np.repeat(["A", "B"], repeats=n_half).tolist()
+    adata_pbmc3k.obs["batch"] = adata_pbmc3k.obs["batch"].astype("category")
+
+    # Create coordinates using numpy's random generator with fixed seed
+    rng = np.random.Generator(np.random.PCG64(42))
+    coords = np.zeros((n_obs, 2))
+
+    # First half - batch A: concentric rings structure
+    # Inner ring
+    inner_count = n_half // 3
+    angles_inner = rng.uniform(0, 2 * np.pi, inner_count)
+    radii_inner = rng.normal(5, 1, inner_count)  # Smaller radius with less variation
+    coords[:inner_count, 0] = radii_inner * np.cos(angles_inner)
+    coords[:inner_count, 1] = radii_inner * np.sin(angles_inner)
+
+    # Outer ring
+    outer_count = n_half - inner_count
+    angles_outer = rng.uniform(0, 2 * np.pi, outer_count)
+    radii_outer = rng.normal(15, 2, outer_count)  # Larger radius with more variation
+    coords[inner_count:n_half, 0] = radii_outer * np.cos(angles_outer)
+    coords[inner_count:n_half, 1] = radii_outer * np.sin(angles_outer)
+
+    # Second half - batch B: grid-like structure with noise that overlaps with batch A
+    # Create a grid that overlaps with the inner ring from batch A
+    grid_size = int(np.sqrt(n_half))
+    x_grid = np.linspace(-10, 10, grid_size)
+    y_grid = np.linspace(-10, 10, grid_size)
+
+    # Create all combinations of x and y coordinates
+    xx, yy = np.meshgrid(x_grid, y_grid)
+    grid_points = np.column_stack([xx.ravel(), yy.ravel()])
+
+    # Add some noise to the grid points
+    grid_points += rng.normal(0, 1, size=grid_points.shape)
+
+    # Use the grid points (or as many as needed)
+    max_points = min(grid_points.shape[0], n_half)
+    coords[n_half : n_half + max_points] = grid_points[:max_points]
+
+    # If we need more points than the grid provides, add random points
+    if max_points < n_half:
+        remaining = n_half - max_points
+        random_points = rng.uniform(-10, 10, size=(remaining, 2))
+        coords[n_half + max_points :] = random_points
+
+    # Add the spatial coordinates to the AnnData object
+    adata_pbmc3k.obsm["spatial"] = coords
+
+    return adata_pbmc3k
+
+
+@pytest.fixture
 def query_reference_adata(adata_pbmc3k):
     # Define the number of query cells and genes
     n_query_cells = 500

--- a/tests/test_cellmapper.py
+++ b/tests/test_cellmapper.py
@@ -417,7 +417,7 @@ class TestSelfMapping:
         assert "leiden_conf" in cm.query.obs
 
     @pytest.mark.parametrize("include_self", [True, False])
-    def test_load_distances_with_include_self(self, adata_spatial):
+    def test_load_distances_with_include_self(self, adata_spatial, include_self):
         """Test loading precomputed distances with and without self-connections."""
 
         # Compute neighbors with scanpy

--- a/tests/test_cellmapper.py
+++ b/tests/test_cellmapper.py
@@ -404,9 +404,10 @@ class TestSelfMapping:
             assert cm.knn.xx.n_neighbors >= 3, "Delaunay should create at least a few connections per cell"
 
         if "set_diag" in squidpy_params and squidpy_params["set_diag"]:
-            # If diagonal is set, cell should be its own neighbor
-            for i in range(min(10, cm.knn.xx.n_samples)):  # Check first 10 cells
-                assert i in cm.knn.xx.indices[i]
+            assert (
+                adata_spatial.obsp["spatial_connectivities"].diagonal()
+                == cm.knn.xx.boolean_adjacency(set_diag=True).diagonal()
+            ).all()
 
         # Test the mapping pipeline
         cm.compute_mappping_matrix(method="gaussian")

--- a/tests/test_cellmapper.py
+++ b/tests/test_cellmapper.py
@@ -56,9 +56,9 @@ class TestCellMapper:
             n_pca_components=n_pca_components,
             pca_kwargs=pca_kwargs,
         )
-        assert joint_pca_key in cmap.ref.obsm
+        assert joint_pca_key in cmap.reference.obsm
         assert joint_pca_key in cmap.query.obsm
-        assert cmap.ref.obsm[joint_pca_key].shape[1] == n_pca_components
+        assert cmap.reference.obsm[joint_pca_key].shape[1] == n_pca_components
         assert cmap.query.obsm[joint_pca_key].shape[1] == n_pca_components
 
     @pytest.mark.parametrize(
@@ -89,8 +89,8 @@ class TestCellMapper:
 
     def test_transfer_labels_self_mapping(self, query_ref_adata):
         """Check mapping to self."""
-        _, ref = query_ref_adata
-        cm = CellMapper(ref, ref)
+        _, reference = query_ref_adata
+        cm = CellMapper(reference, reference)
         cm.fit(
             knn_method="sklearn",
             mapping_method="jaccard",
@@ -99,12 +99,12 @@ class TestCellMapper:
             n_neighbors=1,
             prediction_postfix="transfer",
         )
-        assert "leiden_transfer" in ref.obs
-        assert len(ref.obs["leiden_transfer"]) == len(ref.obs["leiden"])
+        assert "leiden_transfer" in reference.obs
+        assert len(reference.obs["leiden_transfer"]) == len(reference.obs["leiden"])
         # Check that all predicted labels are valid categories
-        assert set(ref.obs["leiden_transfer"].cat.categories) <= set(ref.obs["leiden"].cat.categories)
+        assert set(reference.obs["leiden_transfer"].cat.categories) <= set(reference.obs["leiden"].cat.categories)
         # If mapping to self, labels should match
-        assert ref.obs["leiden_transfer"].equals(ref.obs["leiden"])
+        assert reference.obs["leiden_transfer"].equals(reference.obs["leiden"])
 
     def test_query_imputed_property_numpy_array(self, cmap, random_imputed_data):
         """Test setting query_imputed with a numpy array."""
@@ -118,7 +118,7 @@ class TestCellMapper:
 
         # Verify metadata was copied correctly
         assert cmap.query_imputed.obs.equals(cmap.query.obs)
-        assert cmap.query_imputed.var.equals(cmap.ref.var)
+        assert cmap.query_imputed.var.equals(cmap.reference.var)
 
         # Test evaluation works with custom imputed data
         cmap.evaluate_expression_transfer(layer_key="X", method="pearson")
@@ -200,7 +200,7 @@ class TestCellMapper:
 
         # Verify query_imputed was set
         assert cmap.query_imputed is not None
-        assert cmap.query_imputed.X.shape == (cmap.query.n_obs, cmap.ref.n_vars)
+        assert cmap.query_imputed.X.shape == (cmap.query.n_obs, cmap.reference.n_vars)
 
         if issparse(cmap.query_imputed.X):
             # For sparse data, we'll convert a small subset to dense for comparison
@@ -238,7 +238,7 @@ class TestCellMapper:
 
         # Check that obs and var have the same contents
         assert cmap.query_imputed.obs.equals(cmap.query.obs)
-        assert cmap.query_imputed.var.equals(cmap.ref.var)
+        assert cmap.query_imputed.var.equals(cmap.reference.var)
 
         # Modify query.obs
         test_key = "_test_metadata_update"

--- a/tests/test_cellmapper.py
+++ b/tests/test_cellmapper.py
@@ -87,9 +87,9 @@ class TestCellMapper:
             assert cmap.query_imputed is not None
             assert cmap.query_imputed.X.shape[0] == cmap.query.n_obs
 
-    def test_transfer_labels_self_mapping(self, query_ref_adata):
+    def test_transfer_labels_self_mapping(self, query_reference_adata):
         """Check mapping to self."""
-        _, reference = query_ref_adata
+        _, reference = query_reference_adata
         cm = CellMapper(reference, reference)
         cm.fit(
             knn_method="sklearn",

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -29,8 +29,8 @@ class TestEvaluate:
     )
     def test_presence_score_overall(self, cmap, log, percentile):
         cmap.estimate_presence_score(log=log, percentile=percentile)
-        assert "presence_score" in cmap.ref.obs
-        scores = cmap.ref.obs["presence_score"]
+        assert "presence_score" in cmap.reference.obs
+        scores = cmap.reference.obs["presence_score"]
         assert isinstance(scores, pd.Series | np.ndarray)
         assert np.all((scores >= 0) & (scores <= 1))
         assert not np.all(scores == 0)  # Should not be all zeros
@@ -39,10 +39,10 @@ class TestEvaluate:
     def test_presence_score_groupby(self, cmap, groupby):
         cmap.estimate_presence_score(groupby=groupby)
         # Overall score should always be present in .obs
-        assert "presence_score" in cmap.ref.obs
+        assert "presence_score" in cmap.reference.obs
         # Per-group scores should be present in .obsm
-        assert "presence_score" in cmap.ref.obsm
-        df = cmap.ref.obsm["presence_score"]
+        assert "presence_score" in cmap.reference.obsm
+        df = cmap.reference.obsm["presence_score"]
         assert isinstance(df, pd.DataFrame)
         assert all(np.all((df[col] >= 0) & (df[col] <= 1)) for col in df.columns)
         # Columns should match group names

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -1,5 +1,7 @@
 import numpy as np
 import pytest
+import scanpy as sc
+from scipy.sparse import csr_matrix
 
 from cellmapper.knn import Neighbors
 
@@ -42,3 +44,132 @@ class TestNeighbors:
         neigh.compute_neighbors(n_neighbors=2, method="sklearn")
         r2 = repr(neigh)
         assert "xx=True" in r2 and "yy=True" in r2 and "xy=True" in r2 and "yx=True" in r2
+
+    def test_from_distances_factory_method(self, small_data):
+        """Test the from_distances factory method for creating Neighbors from a distance matrix."""
+        # Create a basic distance matrix
+        n_samples = 5
+        distances_data = np.zeros((n_samples, n_samples))
+        # Fill with distance values (using Euclidean distance for simplicity)
+        x, _ = small_data
+        for i in range(n_samples):
+            for j in range(n_samples):
+                distances_data[i, j] = np.linalg.norm(x[i] - x[j])
+        distances = csr_matrix(distances_data)
+
+        # Create Neighbors object using factory method
+        neighbors = Neighbors.from_distances(distances)
+
+        # Verify the object is created correctly
+        assert neighbors is not None
+        assert neighbors._is_self_mapping
+        assert neighbors.xx is not None
+        assert neighbors.yy is not None
+        assert neighbors.xy is not None
+        assert neighbors.yx is not None
+
+        # All neighbor matrices should be identical for self-mapping
+        assert neighbors.xx is neighbors.yy
+        assert neighbors.xx is neighbors.xy
+        assert neighbors.xx is neighbors.yx
+
+        # Test with the neighbors results
+        nn_results = neighbors.xx
+        assert nn_results.n_samples == n_samples
+        assert nn_results.n_neighbors == n_samples
+
+        # Get adjacency matrix and verify it reflects the original distances
+        adj_matrix = nn_results.knn_graph_distances
+        assert adj_matrix.shape == (n_samples, n_samples)
+        # Check that diagonal is zero (self-distance)
+        assert np.allclose(adj_matrix.diagonal(), 0)
+
+    @pytest.mark.parametrize("n_neighbors", [2, 3, 5])
+    def test_from_distances_varying_neighbors(self, n_neighbors):
+        """Test from_distances with distance matrices containing varying numbers of neighbors."""
+        n_samples = 10
+        # Create distance matrix with only n_neighbors per cell
+        rows, cols, data = [], [], []
+
+        for i in range(n_samples):
+            # Add diagonal element (self)
+            rows.append(i)
+            cols.append(i)
+            data.append(0.0)
+
+            # Add n_neighbors-1 other neighbors with increasing distances
+            for j in range(1, n_neighbors):
+                neighbor_idx = (i + j) % n_samples  # Simple circular pattern
+                rows.append(i)
+                cols.append(neighbor_idx)
+                data.append(float(j))  # Distance increases with j
+
+        distances = csr_matrix((data, (rows, cols)), shape=(n_samples, n_samples))
+
+        # Create Neighbors object
+        neighbors = Neighbors.from_distances(distances)
+
+        # Check the number of neighbors
+        assert neighbors.xx.n_samples == n_samples
+        assert neighbors.xx.n_neighbors == n_neighbors
+
+        # Verify the connectivities
+        connectivities = neighbors.xx.knn_graph_connectivities()
+        assert connectivities.shape == (n_samples, n_samples)
+        assert np.count_nonzero(connectivities.toarray()[0]) == n_neighbors
+
+    def test_from_distances_with_spatial_structure(self, adata_spatial):
+        """Test from_distances with a realistic spatial structure."""
+
+        # Compute standard scanpy neighbors
+        sc.pp.neighbors(adata_spatial, n_neighbors=10, use_rep="X_pca")
+
+        # Extract the distance matrix
+        distances = adata_spatial.obsp["distances"]
+
+        # Create Neighbors object from distances
+        neighbors = Neighbors.from_distances(distances)
+
+        # Verify basic properties
+        assert neighbors is not None
+        assert neighbors.xx.n_samples == adata_spatial.n_obs
+
+        # Compare kNN graphs
+        knn_graph = neighbors.xx.knn_graph_connectivities()
+        original_conn = adata_spatial.obsp["connectivities"]
+
+        # The graphs might not be identical, but should have similar properties
+        assert knn_graph.shape == original_conn.shape
+        assert np.isclose(knn_graph.sum(), original_conn.sum(), rtol=0.1)
+
+    @pytest.mark.parametrize("kernel", ["gaussian", "scarches", "inverse_distance"])
+    def test_from_distances_different_kernels(self, kernel):
+        """Test different kernels with distances from Neighbors.from_distances."""
+        n_samples = 10
+        # Create a simple distance matrix
+        distances_data = np.zeros((n_samples, n_samples))
+        for i in range(n_samples):
+            for j in range(n_samples):
+                if i != j:
+                    distances_data[i, j] = abs(i - j)  # Simple metric: difference in indices
+
+        distances = csr_matrix(distances_data)
+
+        # Create Neighbors object
+        neighbors = Neighbors.from_distances(distances)
+
+        # Compute connectivities with different kernels
+        connectivities = neighbors.xx.knn_graph_connectivities(kernel=kernel)
+
+        # Basic checks
+        assert connectivities.shape == (n_samples, n_samples)
+        # All kernels should produce positive values
+        assert np.all(connectivities.data > 0)
+        # Diagonal should be large values (except for random kernel)
+        if kernel != "random":
+            diag_indices = list(range(n_samples))
+            diag_values = connectivities[diag_indices, diag_indices].toarray().flatten()
+            # Diagonal elements should typically be the largest for each row
+            for i in range(n_samples):
+                row = connectivities.getrow(i).toarray().flatten()
+                assert diag_values[i] >= np.max(row) or np.isclose(diag_values[i], np.max(row))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,23 +84,25 @@ class TestExtractNeighborsFromDistances:
         assert nbr_distances.size == 0
 
     def test_infinite_values(self):
-        """Test with a matrix containing infinite values."""
+        """Test that infinite values are preserved in the neighbor matrix."""
         # Create a distance matrix with some infinite values
         distances_data = np.array(
             [[0.0, 1.0, np.inf, 3.0], [1.0, 0.0, 4.0, np.inf], [np.inf, 4.0, 0.0, 6.0], [3.0, np.inf, 6.0, 0.0]]
         )
         distances = csr_matrix(distances_data)
 
-        # Extract neighbors
-        indices, nbr_distances = extract_neighbors_from_distances(distances)
+        # Extract neighbors with include_self=True
+        indices, nbr_distances = extract_neighbors_from_distances(distances, include_self=True)
 
-        # Check shapes - should exclude infinite values
-        assert indices.shape == (4, 3)  # One less neighbor per cell
-        assert nbr_distances.shape == (4, 3)
+        # Check for a specific cell with infinite distance
+        row0_neighbors = indices[0]
+        assert 2 in row0_neighbors, "Neighbor with infinite distance should be included"
 
-        # Check that infinite values are excluded
-        for i in range(4):
-            assert np.all(np.isfinite(nbr_distances[i]))
+        # Find where the infinite value is in the results
+        idx = np.where(row0_neighbors == 2)[0][0]
+
+        # Verify the distance is infinite
+        assert np.isinf(nbr_distances[0, idx]), "Distance should be infinite"
 
     def test_include_self_parameter(self):
         """Test the include_self parameter to control self-connections."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,3 +86,30 @@ class TestExtractNeighborsFromDistances:
         # Check that infinite values are excluded
         for i in range(4):
             assert np.all(np.isfinite(nbr_distances[i]))
+
+    def test_include_self_parameter(self):
+        """Test the include_self parameter to control self-connections."""
+        # Create a distance matrix with self-connections (diagonal = 0)
+        distances_data = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 4.0, 5.0], [2.0, 4.0, 0.0, 6.0], [3.0, 5.0, 6.0, 0.0]]
+        )
+        distances = csr_matrix(distances_data)
+
+        # Test with include_self=True (default)
+        indices_with_self, distances_with_self = extract_neighbors_from_distances(distances, include_self=True)
+
+        # Test with include_self=False
+        indices_without_self, distances_without_self = extract_neighbors_from_distances(distances, include_self=False)
+
+        # With include_self=True, diagonal elements should be included
+        # (self should be the first neighbor because distance is 0)
+        for i in range(4):
+            assert indices_with_self[i, 0] == i
+            assert distances_with_self[i, 0] == 0.0
+
+        # With include_self=False, diagonal elements should be excluded
+        for i in range(4):
+            # The self-index should not be in the neighbors
+            assert i not in indices_without_self[i]
+            # Check that no zero distances are present
+            assert np.all(distances_without_self[i] > 0)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,88 @@
+import numpy as np
+import pytest
+from scipy.sparse import csr_matrix
+
+from cellmapper.utils import extract_neighbors_from_distances
+
+
+class TestExtractNeighborsFromDistances:
+    """Tests for the extract_neighbors_from_distances function."""
+
+    def test_basic_extraction(self):
+        """Test basic extraction from a simple distance matrix."""
+        # Create a simple distance matrix
+        distances_data = np.array(
+            [[0.0, 1.0, 2.0, 3.0], [1.0, 0.0, 4.0, 5.0], [2.0, 4.0, 0.0, 6.0], [3.0, 5.0, 6.0, 0.0]]
+        )
+        distances = csr_matrix(distances_data)
+
+        # Extract neighbors
+        indices, nbr_distances = extract_neighbors_from_distances(distances)
+
+        # Check shapes
+        assert indices.shape == (4, 4)
+        assert nbr_distances.shape == (4, 4)
+
+        # Check values - neighbors should be sorted by distance
+        np.testing.assert_array_equal(indices[0], [0, 1, 2, 3])
+        np.testing.assert_array_equal(indices[1], [1, 0, 2, 3])
+        np.testing.assert_array_almost_equal(nbr_distances[0], [0.0, 1.0, 2.0, 3.0])
+        np.testing.assert_array_almost_equal(nbr_distances[1], [0.0, 1.0, 4.0, 5.0])
+
+    def test_sparse_matrix(self):
+        """Test extraction from a sparse distance matrix."""
+        # Create a sparse matrix with only some connections
+        row_idx = [0, 0, 1, 1, 2, 2, 3, 3]
+        col_idx = [0, 1, 1, 0, 2, 0, 3, 2]
+        values = [0.0, 1.0, 0.0, 1.0, 0.0, 2.0, 0.0, 6.0]
+        distances = csr_matrix((values, (row_idx, col_idx)), shape=(4, 4))
+
+        # Extract neighbors
+        indices, nbr_distances = extract_neighbors_from_distances(distances)
+
+        # Check shapes
+        assert indices.shape == (4, 2)  # Only 2 neighbors per cell
+        assert nbr_distances.shape == (4, 2)
+
+        # Check values
+        np.testing.assert_array_equal(indices[0], [0, 1])
+        np.testing.assert_array_equal(indices[2], [2, 0])
+        np.testing.assert_array_almost_equal(nbr_distances[0], [0.0, 1.0])
+        np.testing.assert_array_almost_equal(nbr_distances[2], [0.0, 2.0])
+
+    def test_invalid_input(self):
+        """Test with invalid inputs."""
+        # Test with non-square matrix
+        distances = csr_matrix((3, 4))
+        with pytest.raises(ValueError, match="Square distance matrix"):
+            extract_neighbors_from_distances(distances)
+
+        # Test with non-sparse matrix
+        with pytest.raises(TypeError, match="must be a sparse matrix"):
+            extract_neighbors_from_distances(np.zeros((3, 3)))
+
+    def test_empty_matrix(self):
+        """Test with an empty matrix."""
+        distances = csr_matrix((0, 0))
+        indices, nbr_distances = extract_neighbors_from_distances(distances)
+        assert indices.size == 0
+        assert nbr_distances.size == 0
+
+    def test_infinite_values(self):
+        """Test with a matrix containing infinite values."""
+        # Create a distance matrix with some infinite values
+        distances_data = np.array(
+            [[0.0, 1.0, np.inf, 3.0], [1.0, 0.0, 4.0, np.inf], [np.inf, 4.0, 0.0, 6.0], [3.0, np.inf, 6.0, 0.0]]
+        )
+        distances = csr_matrix(distances_data)
+
+        # Extract neighbors
+        indices, nbr_distances = extract_neighbors_from_distances(distances)
+
+        # Check shapes - should exclude infinite values
+        assert indices.shape == (4, 3)  # One less neighbor per cell
+        assert nbr_distances.shape == (4, 3)
+
+        # Check that infinite values are excluded
+        for i in range(4):
+            assert np.all(np.isfinite(nbr_distances[i]))


### PR DESCRIPTION
First, this PR makes CellMapper more versatile as an evaluation tool for expression imputation computed externally. Second, it allows importing externally computed k-NN graphs (we test for scanpy and squidpy) via a new self-mapping mode. This can be useful e.g. for spatial smoothing, like in UTAG. 