### PR TITLE
chore: adopt cookiecutter-scverse template v0.7.0 updates

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,7 +1,7 @@
 {
   "template": "https://github.com/scverse/cookiecutter-scverse",
-  "commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec",
-  "checkout": "v0.6.0",
+  "commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95",
+  "checkout": "v0.7.0",
   "context": {
     "cookiecutter": {
       "project_name": "cellmapper",
@@ -36,7 +36,7 @@
         "trim_blocks": true
       },
       "_template": "https://github.com/scverse/cookiecutter-scverse",
-      "_commit": "d383d94fadff9e4e6fdb59d77c68cb900d7cedec"
+      "_commit": "6ff5b92b5d44ea6d8a88e47538475718d467db95"
     }
   },
   "directory": null

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug report
 description: Report something that is broken or incorrect
-labels: bug
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Propose a new feature for cellmapper
-labels: enhancement
+type: Enhancement
 body:
   - type: textarea
     id: description

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,14 +19,12 @@ jobs:
   package:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Check package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,14 +20,12 @@ jobs:
     permissions:
       id-token: write # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: pyproject.toml
+        uses: astral-sh/setup-uv@v7
       - name: Build package
         run: uv build
       - name: Publish package distributions to PyPI

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,12 +28,12 @@ jobs:
     outputs:
       envs: ${{ steps.get-envs.outputs.envs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
       - name: Get test environments
         id: get-envs
         run: |
@@ -64,15 +64,14 @@ jobs:
     continue-on-error: ${{ contains(matrix.env.name, 'pre') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           filter: blob:none
           fetch-depth: 0
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.env.python }}
-          cache-dependency-glob: pyproject.toml
       - name: create hatch environment
         run: uvx hatch env create ${{ matrix.env.name }}
       - name: run tests using hatch

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,8 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
+    nodejs: latest
   jobs:
     create_environment:
       - asdf plugin add uv

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,10 +5,13 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 # -- Path setup --------------------------------------------------------------
+import shutil
 import sys
 from datetime import datetime
 from importlib.metadata import metadata
 from pathlib import Path
+
+from sphinxcontrib import katex
 
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE / "extensions"))
@@ -19,7 +22,7 @@ sys.path.insert(0, str(HERE / "extensions"))
 # NOTE: If you installed your project in editable mode, this might be stale.
 #       If this is the case, reinstall it to refresh the metadata
 info = metadata("cellmapper")
-project_name = info["Name"]
+project = info["Name"]
 author = info["Author"]
 copyright = f"{datetime.now():%Y}, {author}."
 version = info["Version"]
@@ -37,7 +40,7 @@ needs_sphinx = "4.0"
 html_context = {
     "display_github": True,  # Integrate GitHub
     "github_user": "quadbio",
-    "github_repo": project_name,
+    "github_repo": project,
     "github_version": "main",
     "conf_py_path": "/docs/",
 }
@@ -54,9 +57,9 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
     "sphinxcontrib.bibtex",
+    "sphinxcontrib.katex",
     "sphinx_autodoc_typehints",
     "sphinx_tabs.tabs",
-    "sphinx.ext.mathjax",
     "IPython.sphinxext.ipython_console_highlighting",
     "sphinxext.opengraph",
     *[p.stem for p in (HERE / "extensions").glob("*.py")],
@@ -121,7 +124,7 @@ html_theme = "sphinx_book_theme"
 html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
-html_title = project_name
+html_title = project
 
 html_theme_options = {
     "repository_url": repository_url,
@@ -135,6 +138,7 @@ html_theme_options = {
 }
 
 pygments_style = "default"
+katex_prerender = shutil.which(katex.NODEJS_BINARY) is not None
 
 nitpick_ignore = [
     # If building the documentation fails because of a missing link that is outside your control,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ optional-dependencies.doc = [
   "sphinx-copybutton",
   "sphinx-tabs",
   "sphinxcontrib-bibtex>=1",
+  "sphinxcontrib-katex",
   "sphinxext-opengraph",
 ]
 optional-dependencies.test = [


### PR DESCRIPTION
Manually adopts relevant changes from [cookiecutter-scverse v0.7.0](https://github.com/scverse/cookiecutter-scverse/releases/tag/v0.7.0).

## Changes adopted

- **Issue templates**: Use `type` instead of `labels` (GitHub's new issue type feature)
- **Actions**: Update `actions/checkout` v4→v5, `astral-sh/setup-uv` v5→v7
- **CI**: Remove `cache-dependency-glob` (v7 has smarter defaults)
- **ReadTheDocs**: Python 3.12→3.13, add nodejs for KaTeX
- **Docs**: Replace MathJax with KaTeX for better math rendering
- **Docs**: Fix `project_name`→`project` variable naming
- **Dependencies**: Add `sphinxcontrib-katex`
- **Cruft**: Update `.cruft.json` to v0.7.0

## Changes skipped (kept our customizations)

- **Shell defaults**: Keep `bash -euo pipefail` for stricter CI error handling
- **Dependency groups**: Keep `optional-dependencies` (not `dependency-groups`) for user-installable extras
- **Docutils pin**: Keep `<0.22` for sphinx-tabs compatibility
- **Python 3.14**: Defer until stable release
- **Codecov OIDC**: Keep token-based auth for now

Closes #58