### PR TITLE
chore: add Python 3.14 to test matrix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,12 +95,12 @@ scripts.clean = "git clean -fdX -- {args:docs}"
 # Test the lowest and highest supported Python versions with normal deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "stable" ]
-python = [ "3.11", "3.13" ]
+python = [ "3.11", "3.14" ]
 
 # Test the newest supported Python version also with pre-release deps
 [[tool.hatch.envs.hatch-test.matrix]]
 deps = [ "pre" ]
-python = [ "3.13" ]
+python = [ "3.14" ]
 
 [tool.hatch.envs.hatch-test]
 features = [ "dev", "test" ]
@@ -152,9 +152,9 @@ lint.per-file-ignores."docs/*" = [ "I" ]
 lint.per-file-ignores."tests/*" = [ "D" ]
 lint.pydocstyle.convention = "numpy"
 
-[tool.pytest.ini_options]
+[tool.pytest]
 testpaths = [ "tests" ]
-xfail_strict = true
+strict = true
 addopts = [
   "--import-mode=importlib", # allow using test files with same name
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-from importlib.resources import files
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -6,6 +6,9 @@ import pytest
 import scanpy as sc
 
 from cellmapper.model.cellmapper import CellMapper
+
+# Get the tests directory path
+TESTS_DIR = Path(__file__).parent
 
 
 @pytest.fixture
@@ -31,7 +34,7 @@ def small_data():
 @pytest.fixture
 def precomputed_leiden():
     """Fixture to load precomputed leiden clustering."""
-    data_path = files("tests.data") / "precomputed_leiden.csv"
+    data_path = TESTS_DIR / "data" / "precomputed_leiden.csv"
     leiden_cl = pd.read_csv(str(data_path), index_col=0)["leiden"]
 
     return leiden_cl


### PR DESCRIPTION
Completes the template v0.7.0 alignment by adding Python 3.14 support.

## Changes

- **Test matrix**: 3.11/3.13 → 3.11/3.14 (stable), pre-release now on 3.14
- **pytest config**: Modernize `[tool.pytest.ini_options]` → `[tool.pytest]` (pytest 8.x style)
- **strict mode**: Replace `xfail_strict = true` with `strict = true`

Python 3.14 was released October 2025, so it's now stable and ready for production testing.