### PR TITLE
Fix HNOCA kernel to be the squared Jarrad kernel

### DIFF
--- a/src/cellmapper/model/kernel.py
+++ b/src/cellmapper/model/kernel.py
@@ -273,7 +273,7 @@ class Kernel:
             if kernel_method == "jaccard":
                 kernel_matrix.data /= 4 * n_neighbors - kernel_matrix.data
             elif kernel_method == "hnoca":
-                kernel_matrix.data /= 2 * n_neighbors - kernel_matrix.data
+                kernel_matrix.data /= 4 * n_neighbors - kernel_matrix.data
                 kernel_matrix.data = kernel_matrix.data**2
 
         elif kernel_method in PackageConstants.CONNECTIVITY_BASED_KERNELS:


### PR DESCRIPTION
Closes #64

## Summary

- Changes denominator in the HNOCA kernel from `2 * n_neighbors` to `4 * n_neighbors`, making HNOCA exactly the Jarrad kernel squared

## Details

The HNOCA kernel is defined as the Jarrad kernel squared. The Jarrad kernel normalizes overlap as:

```
overlap / (4k - overlap)
```

Previously, the HNOCA base expression used `2k` instead of `4k` before squaring, which deviated from the original HNOCA-tools implementation. This single-character fix aligns it correctly.