### PR TITLE
Update Jupyter/tutorial environment dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ optional-dependencies.doc = [
   "docutils>=0.8,!=0.18.*,!=0.19.*,<0.22", # sphinx-tabs incompatible with 0.22, see https://github.com/executablebooks/sphinx-tabs/issues/206
   "ipykernel",
   "ipython",
+  "ipywidgets",                            # for tqdm/notebook progress bars in Jupyter
   "myst-nb>=1.1",
   "pandas",
   # Until pybtex >0.24.0 releases: https://bitbucket.org/pybtex-devs/pybtex/issues/169/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.test = [
   "faiss-cpu",
   "pytest",
   "pytest-cov",     # For VS Code's coverage functionality
-  "squidpy>=1.6",
+  "squidpy>=1.8",
 ]
 optional-dependencies.tutorials = [
   "harmony-pytorch",
@@ -71,8 +71,8 @@ optional-dependencies.tutorials = [
   "python-louvain",
   "scvi-tools>=1.3",
   "seaborn",
-  "sopa>=2",
-  "squidpy>=1.6",
+  "sopa>=2.2",
+  "squidpy>=1.8",
 ]
 # https://docs.pypi.org/project_metadata/#project-urls
 urls.Documentation = "https://cellmapper.readthedocs.io/"


### PR DESCRIPTION
Dependency hygiene for the documentation, tutorial, and test environments. No changes to the core (runtime) dependency set.

## Changes (all in `pyproject.toml`)

**`doc` extra**
- Add `ipywidgets` — `tqdm`'s notebook backend emits `TqdmWarning: IProgress not found` and progress bars don't render without it.

**`test` + `tutorials` extras**
- `squidpy>=1.6` → `squidpy>=1.8`
- `sopa>=2` → `sopa>=2.2` (tutorials)

## Why the floor bumps

The previous floors resolved to old transitive versions that emit deprecation warnings when importing the tutorial stack. Raising the *declared* floors (rather than patching only the local lock) guarantees warning-free transitive resolution:

- `squidpy>=1.8` requires `spatialdata>=0.7.1`
- `sopa>=2.2` requires `spatialdata>=0.7.3`
- `spatialdata 0.7.x` requires `dask>=2025.12.0`

This eliminates three warnings in the doc/tutorial/test environment:
- legacy Dask DataFrame `FutureWarning` (modern dask has query-planning built in)
- `spatialdata` `functools.partial` `FutureWarning`s on Python 3.13
- `pkg_resources` deprecation warning (newer `spatialdata` no longer depends on `xarray-schema`)

## Verification
- `pyproject.toml` ⟷ `uv.lock` ⟷ `.venv` all consistent (`uv lock --check` + `uv sync --dry-run` clean).
- Target warnings confirmed gone on import of the tutorial stack.
- Test suite: 184 passed (the 2 pre-existing `mocker`-fixture errors are unrelated — `pytest-mock` is missing from the test extra; fixed separately).

## Note
`uv.lock` is intentionally not committed — it is gitignored in this repo, and CellMapper is a library tested across multiple dependency resolutions (`hatch-test` stable/pre matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)