### PR TITLE
Add pytest-mock to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ optional-dependencies.test = [
   "faiss-cpu",
   "pytest",
   "pytest-cov",     # For VS Code's coverage functionality
+  "pytest-mock",
   "squidpy>=1.6",
 ]
 optional-dependencies.tutorials = [


### PR DESCRIPTION
## Summary

`tests/test_check.py` uses the `mocker` fixture (provided by the `pytest-mock` plugin), but `pytest-mock` was not declared in the `test` optional-dependencies group in `pyproject.toml`. As a result, two tests errored with `fixture 'mocker' not found`:

- `tests/test_check.py::TestCheck::test_checker_missing_metadata_no_vmin`
- `tests/test_check.py::TestCheck::test_checker_missing_metadata_with_vmin`

This PR adds `"pytest-mock"` to the `optional-dependencies.test` list (alphabetically, next to the other pytest entries).

## Verification

After `uv lock` and `uv sync --all-extras`, all tests pass:

```
$ uv run pytest tests/test_check.py
collected 7 items
tests/test_check.py .......                                              [100%]
============================== 7 passed in 0.02s ===============================
```

(Previously, 2 of these 7 errored.)

https://claude.ai/code/session_011rA6FSCCjfQFg34RgM7Mv8

---
_Generated by [Claude Code](https://claude.ai/code/session_011rA6FSCCjfQFg34RgM7Mv8)_