### PR TITLE
Add pytest-mock to test extra (fix mocker fixture errors)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional-dependencies.test = [
   "faiss-cpu",
   "pytest",
   "pytest-cov",     # For VS Code's coverage functionality
+  "pytest-mock",    # provides the `mocker` fixture used in tests/test_check.py
   "squidpy>=1.8",
 ]
 optional-dependencies.tutorials = [


### PR DESCRIPTION
## What
Adds `pytest-mock` to the `test` optional-dependencies group.

## Why
`tests/test_check.py` uses the `mocker` fixture (provided by the `pytest-mock` plugin), but `pytest-mock` was never declared as a test dependency. In a clean test environment two tests error with `fixture 'mocker' not found`:

- `tests/test_check.py::TestCheck::test_checker_missing_metadata_no_vmin`
- `tests/test_check.py::TestCheck::test_checker_missing_metadata_with_vmin`

## Verification
With `pytest-mock` declared and installed: `pytest tests/test_check.py` → **7 passed** (previously 5 passed, 2 errored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)