### PR TITLE
Add cellrank to tutorials extra; override pygpcca jinja2 pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ optional-dependencies.test = [
   "squidpy>=1.8",
 ]
 optional-dependencies.tutorials = [
+  "cellrank>=2",
   "harmony-pytorch",
   "igraph",
   "netgraph",
@@ -100,6 +101,12 @@ envs.hatch-test.matrix = [
 envs.hatch-test.overrides.matrix.deps.env-vars = [
   { value = "allow", key = "UV_PRERELEASE", if = [ "pre" ] },
 ]
+
+[tool.uv]
+# pygpcca 1.0.4 (pulled in by cellrank, tutorials extra) incorrectly pins
+# jinja2==3.0.3, which conflicts with sphinx (doc extra). Override until a
+# pygpcca release relaxes it. jinja2>=3.1 is known-safe (cellrank does the same).
+override-dependencies = [ "jinja2>=3.1" ]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## What

- Add `cellrank>=2` to the `tutorials` optional-dependencies group. It's imported by the CellRank/pseudotime tutorial notebook (`from cellrank.kernels import PseudotimeKernel`, `from cellrank.estimators import GPCCA`), which currently fails with `ModuleNotFoundError: No module named 'cellrank'`.
- Add `[tool.uv] override-dependencies = ["jinja2>=3.1"]`.

## Why the override

`cellrank` pulls in `pygpcca` (needed for the `GPCCA` estimator), and `pygpcca` 1.0.4 — the latest release — incorrectly hard-pins `jinja2==3.0.3`. That collides with `sphinx>=8.1` in the `doc` extra, which requires `jinja2>=3.1`. Because `uv sync --all-extras` resolves every extra into one universal lock, the two extras become mutually unsatisfiable and the sync fails:

```
cellmapper[doc] and cellmapper[tutorials] are incompatible
... your project's requirements are unsatisfiable
```

The `override-dependencies` entry forces a single `jinja2>=3.1` across the resolution, neutralizing pygpcca's overly strict pin. This is known-safe — upstream CellRank ships the same override for the same reason. The comment notes it can be dropped once a pygpcca release relaxes the pin.

## Verification

`uv sync --all-extras` resolves and installs cleanly, and the tutorial's imports load:

```
cellrank   2.0.7
jinja2     3.1.6   (sphinx-compatible; pygpcca pin overridden)
```

`sphinx` and `ipykernel` are unaffected, so the docs build and Jupyter kernel keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)