### PR TITLE
Add gpcca-fast dependency group for pyGPCCA krylov backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,25 @@ urls.Documentation = "https://cellmapper.readthedocs.io/"
 urls.Homepage = "https://github.com/quadbio/cellmapper"
 urls.Source = "https://github.com/quadbio/cellmapper"
 
+# Opt-in fast backend for pyGPCCA (pulled in by cellrank's tutorials extra).
+# Without petsc4py/slepc4py, pyGPCCA falls back to method='brandts', which
+# densifies the transition matrix and warns. This is a PEP 735 dependency group
+# (NOT an extra) on purpose: petsc/slepc have no wheels and compile from source,
+# so we keep them out of `uv sync --all-extras` and require an explicit opt-in.
+#
+# The build needs a C compiler only (no Fortran/MPI/system libs) IF you pass
+# PETSC_CONFIGURE_OPTIONS. Do NOT set SLEPC_CONFIGURE_OPTIONS — SLEPc inherits
+# config from the built PETSc. Install (one-time source build, ~4 min, cached):
+#   PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1" \
+#     uv sync --all-extras --group gpcca-fast
+[dependency-groups]
+gpcca-fast = [
+  "petsc",
+  "petsc4py",
+  "slepc",
+  "slepc4py",
+]
+
 [tool.hatch]
 version.source = "vcs"
 envs.default.installer = "uv"


### PR DESCRIPTION
## Summary

cellrank (`tutorials` extra) pulls in pyGPCCA, which falls back to `method='brandts'` — densifying the transition matrix and emitting `WARNING: Unable to import petsc4py or slepc4py ...` / `Densifying` — unless `petsc4py`/`slepc4py` are installed. This adds those packages via a PEP 735 `[dependency-groups]` group (`gpcca-fast`) so the fast `method='krylov'` path is available under the uv setup, without conda-forge.

## Behavior Or Invariants Changed

None at runtime. Packaging only: adds an opt-in `[dependency-groups]` table. The group is **not** part of `uv sync --all-extras`, so the default install/refresh stays wheel-only and build-free. CI (`hatch-test`, features `dev`+`test`) and RTD (`hatch run docs:build`, feature `doc`) do not reference the group, so neither builds PETSc.

## Tests Run

- `uv pip install petsc petsc4py slepc slepc4py` with `PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1"` → PETSc 3.25.2 + SLEPc 3.25.1 compiled from source on macOS arm64 with a C compiler only (no Fortran/MPI/system libs).
- `petsc4py` and `slepc4py` import and report their versions.
- pyGPCCA `GPCCA(..., method='krylov').optimize()` run under `warnings.simplefilter('error')` → passes, confirming the `brandts`/densify fallback is gone.
- `uv sync --all-extras --dry-run` → resolves **without** petsc/slepc (group correctly excluded).
- `uv sync --all-extras --group gpcca-fast --dry-run` → resolves **with** all four packages.
- `pre-commit` ran via the commit hook (`pyproject-fmt` passed).

## Reviewer Focus

`pyproject.toml` — the new `[dependency-groups]` table and the accompanying comment documenting the build recipe. Two non-obvious points captured there: pass the configure flags via `PETSC_CONFIGURE_OPTIONS`, and do **not** set `SLEPC_CONFIGURE_OPTIONS` (SLEPc inherits config from the built PETSc; passing `--with-mpi` there errors).

## Context

petsc/slepc have no wheels, so they compile from source (~4 min one-time, then cached by uv). A dependency group rather than an optional-dependencies extra was a deliberate choice: it keeps the heavy source build an explicit opt-in and avoids forcing the `PETSC_CONFIGURE_OPTIONS` env var onto every `uv sync --all-extras`. Install with:

```bash
PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1" \
  uv sync --all-extras --group gpcca-fast
```

## Open Questions Or Follow-Ups

- Could be documented in `docs/contributing.md` if we want the recipe discoverable outside the pyproject comment.
- The serial (`--with-mpi=0`) build is intentional for single-machine pyGPCCA use; an MPI build would require system MPI + the conda-forge route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)