### PR TITLE
Drop Python 3.11 support (require >=3.12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ This file only owns the project invariants and source-of-truth map below.
 
 ## Development Commands
 
-Python 3.11 and 3.14 (see the `hatch-test` matrix in `pyproject.toml`).
+Python 3.12 and 3.14 (see the `hatch-test` matrix in `pyproject.toml`).
 
 ```bash
 hatch test                        # run tests (highest Python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Changed
+- Dropped Python 3.11 support; the minimum supported version is now Python 3.12, aligning with `cellrank` (≥2.1 requires Python ≥3.12) and unpinning the `tutorials` extra from the old `cellrank` 2.0.7 {pr}`PRNUM`
+
 ## [v0.2.5]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning][].
 ## [Unreleased]
 
 ### Changed
-- Dropped Python 3.11 support; the minimum supported version is now Python 3.12, aligning with `cellrank` (≥2.1 requires Python ≥3.12) and unpinning the `tutorials` extra from the old `cellrank` 2.0.7 {pr}`PRNUM`
+- Dropped Python 3.11 support; the minimum supported version is now Python 3.12, aligning with `cellrank` (≥2.1 requires Python ≥3.12) and unpinning the `tutorials` extra from the old `cellrank` 2.0.7 {pr}`81`
 
 ## [v0.2.5]
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The core idea of `CellMapper` is to separate the method (k-NN graph with some ke
 
 ## 📦 Installation
 
-You need to have 🐍 Python 3.11 or newer installed on your system.
+You need to have 🐍 Python 3.12 or newer installed on your system.
 If you don't have Python installed, we recommend installing [uv][].
 
 There are two alternative options to install ``cellmapper``:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,9 @@ maintainers = [
 authors = [
   { name = "Marius Lange" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
@@ -111,7 +110,7 @@ envs.docs.scripts.open = "python -m webbrowser -t docs/_build/html/index.html"
 envs.hatch-test.features = [ "dev", "test" ]
 envs.hatch-test.matrix = [
   # Test the lowest and highest supported Python versions with normal deps
-  { deps = [ "stable" ], python = [ "3.11", "3.14" ] },
+  { deps = [ "stable" ], python = [ "3.12", "3.14" ] },
   # Test the newest supported Python version also with pre-release deps
   { deps = [ "pre" ], python = [ "3.14" ] },
 ]


### PR DESCRIPTION
## Summary

Bump CellMapper's minimum Python from 3.11 to 3.12. `cellrank` requires Python ≥3.12 since 2.1.0, so our `requires-python = ">=3.11"` floor forced uv's universal lock to hold the *entire* dependency graph — including the local kernel venv — back to the last cellrank that still supported 3.11 (**2.0.7**). Dropping 3.11 unpins the `tutorials` extra to **cellrank 2.3.x** (and modernizes scanpy → 1.12, scvi-tools → 1.4.3, etc.).

## Behavior Or Invariants Changed

- **Minimum Python is now 3.12.** `requires-python = ">=3.12"`, the `:: 3.11` trove classifier is removed, and the `hatch-test` matrix moves from `3.11, 3.14` to `3.12, 3.14`. No code/API changes.

## Tests Run

- `uv lock --dry-run` with `requires-python = ">=3.12"` → resolves cleanly (302 packages), cellrank moves off 2.0.7. The same dry-run on the old `>=3.11` floor with a `cellrank>=2.3` probe fails with *"cellrank==2.3.0 depends on Python>=3.12"*, confirming the root cause.
- `pre-commit run --files pyproject.toml README.md AGENTS.md CHANGELOG.md` → passes (`pyproject-fmt` etc.).
- Full `hatch test` matrix not run locally (CI will exercise 3.12/3.14).

## Reviewer Focus

`pyproject.toml` — `requires-python`, classifiers, and the `hatch-test` matrix. Doc touch-ups in `README.md` and `AGENTS.md`. No ruff/mypy `target-version` pins exist (they infer from `requires-python`), so nothing else needed updating.

## Context

This is step 1 of delegating the pyGPCCA fast backend to CellRank. Once a cellrank release ships the mpi4py-free `[petsc]` extra (scverse/cellrank#1362, merged to main), a follow-up will replace the hardcoded `gpcca-fast` group (`petsc petsc4py slepc slepc4py`) with `cellrank[petsc]>=<that release>`. That follow-up is **blocked on the release** and is intentionally not part of this PR.

## Open Questions Or Follow-Ups

- Changelog entry references `{pr}` with a placeholder that will be updated to this PR's number.
- 3.11 is dropped for the whole package, not just the `tutorials` extra — intentional, per maintainer decision, and consistent with the broader scverse ecosystem moving to ≥3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)