### PR TITLE
Delegate gpcca-fast petsc backend to cellrank[petsc]>=2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Changed
 - Dropped Python 3.11 support; the minimum supported version is now Python 3.12, aligning with `cellrank` (≥2.1 requires Python ≥3.12) and unpinning the `tutorials` extra from the old `cellrank` 2.0.7 {pr}`81`
+- The `gpcca-fast` dependency group now delegates `petsc4py`/`slepc4py` to `cellrank[petsc]>=2.3.1` (mpi4py-free) instead of hardcoding them, keeping only an explicit `slepc` to work around slepc4py's missing runtime metadata {pr}`PRNUM`
 
 ## [v0.2.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning][].
 
 ### Changed
 - Dropped Python 3.11 support; the minimum supported version is now Python 3.12, aligning with `cellrank` (≥2.1 requires Python ≥3.12) and unpinning the `tutorials` extra from the old `cellrank` 2.0.7 {pr}`81`
-- The `gpcca-fast` dependency group now delegates `petsc4py`/`slepc4py` to `cellrank[petsc]>=2.3.1` (mpi4py-free) instead of hardcoding them, keeping only an explicit `slepc` to work around slepc4py's missing runtime metadata {pr}`PRNUM`
+- The `gpcca-fast` dependency group now delegates `petsc4py`/`slepc4py` to `cellrank[petsc]>=2.3.1` (mpi4py-free) instead of hardcoding them, keeping only an explicit `slepc` to work around slepc4py's missing runtime metadata {pr}`82`
 
 ## [v0.2.5]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,23 +80,31 @@ urls.Documentation = "https://cellmapper.readthedocs.io/"
 urls.Homepage = "https://github.com/quadbio/cellmapper"
 urls.Source = "https://github.com/quadbio/cellmapper"
 
-# Opt-in fast backend for pyGPCCA (pulled in by cellrank's tutorials extra).
-# Without petsc4py/slepc4py, pyGPCCA falls back to method='brandts', which
-# densifies the transition matrix and warns. This is a PEP 735 dependency group
-# (NOT an extra) on purpose: petsc/slepc have no wheels and compile from source,
-# so we keep them out of `uv sync --all-extras` and require an explicit opt-in.
+# Opt-in fast backend for pyGPCCA (used by cellrank). Without petsc4py/slepc4py,
+# pyGPCCA falls back to method='brandts', which densifies the transition matrix
+# and warns. petsc4py/slepc4py come from cellrank's own `petsc` extra (mpi4py-free
+# since cellrank 2.3.1), so CellRank owns those. This is a PEP 735 dependency
+# group (NOT an extra) on purpose: petsc/slepc have no wheels and compile from
+# source, so we keep them out of `uv sync --all-extras` and require explicit opt-in.
+#
+# `slepc` is listed explicitly because slepc4py's published sdist metadata omits
+# its runtime dep on the `slepc` library package (it's added dynamically at build
+# time), so uv won't install slepc from cellrank[petsc] alone and slepc4py then
+# fails to import with "Library not loaded: libslepc". (petsc4py declares `petsc`
+# correctly, so petsc needs no such workaround.) Drop this once slepc4py — or
+# cellrank's petsc extra — declares slepc.
 #
 # The build needs a C compiler only (no Fortran/MPI/system libs) IF you pass
 # PETSC_CONFIGURE_OPTIONS. Do NOT set SLEPC_CONFIGURE_OPTIONS — SLEPc inherits
 # config from the built PETSc. Install (one-time source build, ~4 min, cached):
 #   PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1" \
 #     uv sync --all-extras --group gpcca-fast
+# NB: a plain `uv sync --all-extras` (without --group gpcca-fast) will UNINSTALL
+# petsc/slepc if present — re-include the group on every refresh to keep them.
 [dependency-groups]
 gpcca-fast = [
-  "petsc",
-  "petsc4py",
-  "slepc",
-  "slepc4py",
+  "cellrank[petsc]>=2.3.1",
+  "slepc>=3.25",
 ]
 
 [tool.hatch]


### PR DESCRIPTION
## Summary

Now that **cellrank 2.3.1** ships an mpi4py-free `[petsc]` extra (scverse/cellrank#1362), the `gpcca-fast` dependency group delegates `petsc4py`/`slepc4py` to `cellrank[petsc]>=2.3.1` instead of hardcoding the package list — CellRank owns it. This is the follow-up to #81 (which dropped Python 3.11 so the graph could resolve cellrank ≥2.1).

```diff
 gpcca-fast = [
-  "petsc",
-  "petsc4py",
-  "slepc",
-  "slepc4py",
+  "cellrank[petsc]>=2.3.1",
+  "slepc>=3.25",
 ]
```

## Behavior Or Invariants Changed

- `gpcca-fast` no longer hardcodes `petsc`/`petsc4py`/`slepc4py`; they come transitively from `cellrank[petsc]`. The fast pyGPCCA `method='krylov'` path is unchanged.
- The opt-in mechanics are unchanged: still a PEP 735 group (not in `--all-extras`), still needs `PETSC_CONFIGURE_OPTIONS` for the C-only source build.

## Why `slepc` is still listed explicitly

`cellrank[petsc]` alone is **not** sufficient: `slepc4py`'s *published* sdist metadata lists only `[numpy, petsc4py]` — it adds its `slepc` runtime dependency *dynamically at build time*, so uv's resolver never installs the `slepc` library package. Result: `import slepc4py` → `ImportError: Library not loaded: @rpath/libslepc.3.25.dylib`. `petsc4py` declares `petsc` correctly (static metadata), so only `slepc` needs the workaround. Drop it once slepc4py — or cellrank's `petsc` extra — declares `slepc`.

## Tests Run

- `uv lock` (with `PETSC_CONFIGURE_OPTIONS` set) → resolves **cellrank 2.3.1 + petsc 3.25.2 + petsc4py 3.25.2 + slepc 3.25.1 + slepc4py 3.25.1**, and **no `mpi4py`**.
- Throwaway-venv proof of the slepc gap: installing `slepc4py` via `cellrank[petsc]` semantics (no explicit slepc) → `slepc` absent, import fails with the dlopen error; adding `slepc>=3.25` → `slepc4py import OK (3, 25, 1)`.
- `pre-commit` passes on the changed files.

## Reviewer Focus

`pyproject.toml` `[dependency-groups].gpcca-fast` and its comment block (documents the slepc4py workaround and the env-var build recipe). No code changes.

## Open Questions Or Follow-Ups

- Changelog `{pr}` placeholder will be updated to this PR's number.
- Upstream cleanup worth considering: have **cellrank's `[petsc]` extra include `slepc`/`petsc`** (the lib packages), or fix `slepc4py` to declare `slepc` statically — either would let CellMapper drop the explicit `slepc` line entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)