### PR TITLE
Fix xdist worker race condition on scanpy dataset cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ uv.lock
 
 # Tests and coverage
 /data/
+/tests/data/scanpy_cache/
 /node_modules/
 /.coverage*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning][].
 
 ## [Unreleased]
 
+### Fixed
+- Fixed intermittent `OSError: Can't synchronously read data (filter returned failure during read)` when running the test suite under `pytest -n auto`, caused by xdist workers racing on scanpy's shared `pbmc3k_raw.h5ad` dataset cache. Each worker now uses its own cache directory.
+
 ## [v0.2.5]
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 import numpy as np
@@ -9,6 +10,24 @@ from cellmapper.model.cellmapper import CellMapper
 
 # Get the tests directory path
 TESTS_DIR = Path(__file__).parent
+
+
+def pytest_configure(config):
+    """Give each pytest-xdist worker its own scanpy dataset cache directory.
+
+    ``sc.datasets.pbmc3k()`` (used by the ``adata_pbmc3k`` fixture) downloads and
+    reads a single shared cache file (``<datasetdir>/pbmc3k_raw.h5ad``). Under
+    ``pytest -n auto`` multiple worker processes race on that file -- one worker
+    reading it while another is still downloading/writing -- which intermittently
+    surfaces as an HDF5 ``OSError: Can't synchronously read data (filter returned
+    failure during read)``. Pointing each worker at its own cache directory
+    removes the shared-file contention entirely.
+    """
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is not None:
+        cache_dir = TESTS_DIR / "data" / "scanpy_cache" / worker_id
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        sc.settings.datasetdir = cache_dir
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixed intermittent HDF5 read failures when running tests under `pytest -n auto` by isolating each xdist worker's scanpy dataset cache to its own directory. Previously, multiple workers would race on the shared `pbmc3k_raw.h5ad` cache file, causing one worker to read while another was still downloading/writing.

## Behavior Or Invariants Changed

- Test suite now creates worker-specific cache directories under `tests/data/scanpy_cache/{worker_id}/`
- Each pytest-xdist worker uses its own isolated scanpy dataset cache, eliminating file contention
- Added `tests/data/scanpy_cache/` to `.gitignore`

## Tests Run

Existing test suite passes. The fix is validated by running tests under parallel execution (`pytest -n auto`), which previously surfaced the race condition intermittently.

## Reviewer Focus

- `pytest_configure()` hook in `conftest.py`: Ensures cache isolation is set up before any tests run
- Environment variable check for `PYTEST_XDIST_WORKER`: Only applies isolation when running under xdist
- Directory creation with `parents=True, exist_ok=True`: Safe for both single-worker and multi-worker scenarios

## Context

The `adata_pbmc3k` fixture uses `sc.datasets.pbmc3k()`, which downloads a large dataset to a shared cache directory. Under parallel test execution, multiple workers attempt to read/write this file simultaneously, causing HDF5 synchronization errors. This is a common issue with pytest-xdist when fixtures depend on shared external resources.

The solution leverages pytest's `pytest_configure` hook to detect xdist workers (via the `PYTEST_XDIST_WORKER` environment variable) and redirect each worker's scanpy cache before any tests execute.

## Open Questions Or Follow-Ups

None. This is a straightforward isolation fix with no behavioral changes to the actual test logic.

https://claude.ai/code/session_018GKskG6NPe5KeUyhSWfLLn