### PR TITLE
Make uv resolve gpcca-fast without compiling PETSc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,11 +94,27 @@ urls.Source = "https://github.com/quadbio/cellmapper"
 # correctly, so petsc needs no such workaround.) Drop this once slepc4py — or
 # cellrank's petsc extra — declares slepc.
 #
-# The build needs a C compiler only (no Fortran/MPI/system libs) IF you pass
-# PETSC_CONFIGURE_OPTIONS. Do NOT set SLEPC_CONFIGURE_OPTIONS — SLEPc inherits
-# config from the built PETSc. Install (one-time source build, ~4 min, cached):
-#   PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 --with-shared-libraries=1" \
-#     uv sync --all-extras --group gpcca-fast
+# petsc4py/slepc4py compute their metadata dynamically at build time. Without help,
+# uv would therefore compile PETSc from source just to *resolve* — breaking every
+# bare `uv sync` / `uv run` / `uv lock`, even when this group is NOT requested. The
+# [[tool.uv.dependency-metadata]] entries under [tool.uv] give uv that metadata
+# statically, so resolution/locking never builds anything; PETSc/SLEPc compile only
+# when the group is actually installed. Keep those entries in sync with this group.
+#
+# INSTALLING the group is the fragile part. The recommended route is pre-built
+# conda-forge binaries (no compiler, no BLAS hunting), e.g. with pixi/mamba:
+#     mamba install -c conda-forge petsc4py slepc4py     # or: pixi add petsc4py slepc4py
+# Building from PyPI source instead needs a C compiler AND a BLAS/LAPACK. The
+# CellRank-documented options alone (--with-fc=0 --with-mpi=0 --with-debugging=0
+# --with-shared-libraries=1) only work on machines that already expose a system
+# BLAS on the linker path; on others PETSc configure fails with "Could not find a
+# functional BLAS". Adding --download-f2cblaslapack=1 gets PETSc to build but then
+# SLEPc fails to link it (`cannot find -lf2cblas`), so for a source build point
+# PETSc at a real shared BLAS instead, e.g.:
+#     PETSC_CONFIGURE_OPTIONS="--with-fc=0 --with-mpi=0 --with-debugging=0 \
+#       --with-shared-libraries=1 --with-blaslapack-dir=$OPENBLAS_ROOT" \
+#       uv sync --all-extras --group gpcca-fast
+# Do NOT set SLEPC_CONFIGURE_OPTIONS — SLEPc inherits config from the built PETSc.
 # NB: a plain `uv sync --all-extras` (without --group gpcca-fast) will UNINSTALL
 # petsc/slepc if present — re-include the group on every refresh to keep them.
 [dependency-groups]
@@ -133,6 +149,19 @@ envs.hatch-test.overrides.matrix.deps.env-vars = [
 # jinja2==3.0.3, which conflicts with sphinx (doc extra). Override until a
 # pygpcca release relaxes it. jinja2>=3.1 is known-safe (cellrank does the same).
 override-dependencies = [ "jinja2>=3.1" ]
+# Static metadata for the gpcca-fast source-only packages so uv can resolve/lock
+# WITHOUT compiling PETSc (see the note above [dependency-groups]). These mirror
+# the deps each package injects dynamically at build time: petsc4py -> petsc,
+# slepc4py -> petsc4py + slepc (slepc4py's own sdist omits slepc). The `petsc`/
+# `slepc` library packages have no Python dependencies. Version omitted -> applies
+# to all versions; petsc & petsc4py (and slepc & slepc4py) are always co-released
+# at matching versions, so uv resolves them in lockstep.
+dependency-metadata = [
+  { name = "petsc", requires-dist = [] },
+  { name = "slepc", requires-dist = [] },
+  { name = "petsc4py", requires-dist = [ "numpy", "petsc" ] },
+  { name = "slepc4py", requires-dist = [ "numpy", "petsc4py", "slepc" ] },
+]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Problem

Any bare `uv` command in this repo (`uv sync`, `uv run`, `uv lock`) tried to **compile PETSc from source** and failed. Root cause:

- There is no committed `uv.lock`, so uv locks the *entire* dependency universe — including the opt-in `gpcca-fast` group (`cellrank[petsc]`, `slepc`).
- `petsc4py`/`slepc4py` ship no wheels and compute their metadata **dynamically at build time**, so uv had to build PETSc just to *resolve* — even with `--no-default-groups` (that only affects install, not locking).
- On machines without a system BLAS on the linker path (isolated CI/uv build envs), PETSc's `configure` then fails with `Could not find a functional BLAS`. (Verified from the actual `configure.log`.)

Net effect: focused runs documented in `AGENTS.md` like `uv run pytest tests/model` were broken out of the box.

## Fix

Add `[[tool.uv.dependency-metadata]]` entries that mirror the deps `petsc4py`/`slepc4py` inject at build time (`petsc4py → petsc`, `slepc4py → petsc4py + slepc`; the two library packages have no Python deps). uv now resolves and locks these from static metadata **without ever building** — resolves in ~5s. PETSc/SLEPc compile only when the `gpcca-fast` group is actually installed.

Also corrected the group's source-build comment, which was copied from CellRank's docs and only works where a system BLAS already exists; it now documents the pre-built **conda-forge/pixi** path as the recommended install, with a shared-BLAS source build as the fallback.

## Verification

- `uv lock` → `Resolved 302 packages in 4.80s`, no build.
- `uv sync --extra test` → installs in ~11s, `petsc4py` correctly **absent** from `.venv`.
- `uv run pytest tests/test_utils.py` → **19 passed**.
- `hatch test tests/test_utils.py` (unchanged path) → **19 passed**.

## Notes

- `uv.lock` stays gitignored (library convention; hatch manages the test matrix and doesn't consume it). The static metadata is what unblocks resolution, so no lockfile is required.
- Keep the `dependency-metadata` entries in sync with the `gpcca-fast` group.
- The `gpcca-fast` *runtime* backend still builds from source only where a real BLAS is available; conda-forge binaries are the robust route (documented). Unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)